### PR TITLE
Apply opacity and rotation to icon style

### DIFF
--- a/index.js
+++ b/index.js
@@ -204,6 +204,10 @@ function colorWithOpacity(color, opacity) {
   return color;
 }
 
+function deg2rad(degrees) {
+  return degrees * Math.PI / 180;
+}
+
 var spriteRegEx = /^(.*)(\?access_token=.*)$/;
 
 function toSpriteUrl(url, extension) {
@@ -425,7 +429,7 @@ function getStyleFunction(glStyle, source, resolutions, onChange) {
           }
           if (style) {
             var iconImg = style.getImage();
-            iconImg.setRotation(paint['icon-rotate'](zoom));
+            iconImg.setRotation(deg2rad(paint['icon-rotate'](zoom)));
             iconImg.setOpacity(paint['icon-opacity'](zoom));
             style.setZIndex(i);
             styles[stylesLength] = style;

--- a/index.js
+++ b/index.js
@@ -420,6 +420,9 @@ function getStyleFunction(glStyle, source, resolutions, onChange) {
             });
           }
           if (style) {
+            var iconImg = style.getImage();
+            iconImg.setRotation(paint['icon-rotate'] || 0);
+            iconImg.setOpacity(paint['icon-opacity'] || 1);
             style.setZIndex(i);
             styles[stylesLength] = style;
           }

--- a/index.js
+++ b/index.js
@@ -16,7 +16,9 @@ var functions = {
     'fill-opacity',
     'line-opacity',
     'line-width',
-    'text-size'
+    'text-size',
+    'icon-opacity',
+    'icon-rotate'
   ],
   'piecewise-constant': [
     'fill-color',
@@ -35,7 +37,9 @@ var defaults = {
   'text-halo-color': 'rgba(0, 0, 0, 0)',
   'text-halo-width': 0,
   'text-max-width': 10,
-  'text-size': 16
+  'text-size': 16,
+  'icon-opacity': 1,
+  'icon-rotate': 0
 };
 
 function applyDefaults(properties) {
@@ -421,8 +425,8 @@ function getStyleFunction(glStyle, source, resolutions, onChange) {
           }
           if (style) {
             var iconImg = style.getImage();
-            iconImg.setRotation(paint['icon-rotate'] || 0);
-            iconImg.setOpacity(paint['icon-opacity'] || 1);
+            iconImg.setRotation(paint['icon-rotate'](zoom));
+            iconImg.setOpacity(paint['icon-opacity'](zoom));
             style.setZIndex(i);
             styles[stylesLength] = style;
           }


### PR DESCRIPTION
This applies possible opacity and rotation values defined in the Mapbox style to the ``ol.style.Icon`` object.

The assignment is done outside the caching object (``iconImageCache``) by purpose to ensure an icon can be reused with different opacity and rotation values. 